### PR TITLE
feat: add scripts for planning simulator

### DIFF
--- a/scripts/launch_psim.sh
+++ b/scripts/launch_psim.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ./vars/vehicle.env
+
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$MAP_PATH vehicle_model:=$VEHICLE_MODEL sensor_model:=$SENSOR_MODEL

--- a/scripts/set_obstacles.sh
+++ b/scripts/set_obstacles.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+PubDummyObject() {
+  ros2 topic pub -1 /simulation/dummy_perception_publisher/object_info dummy_perception_publisher/msg/Object "header:
+  stamp: now
+  frame_id: "map"
+initial_state:
+  pose_covariance:
+    pose:
+      position:
+        x: $1
+        y: $2
+        z: $3
+      orientation:
+        x: $4
+        y: $5
+        z: $6
+        w: $7
+classification:
+  label: 0
+shape:
+  dimensions:
+    x: $8
+    y: $9
+    z: ${10}"
+}
+
+# First Wall
+PubDummyObject 3796.7 73759.2 0.0 0.0 0.0 -0.9721 0.2347 0.5 1.5 1.0
+
+# Second Wall
+PubDummyObject 3786.4 73756.9 0.0 0.0 0.0 -0.9721 0.2347 0.5 1.5 1.0
+
+# Third Wall
+PubDummyObject 3778.7 73750.1 0.0 0.0 0.0 -0.9721 0.2347 0.5 2.0 1.0
+
+# Fourth Wall
+PubDummyObject 3758.35 73741.8 0.0 0.0 0.0 -0.9721 0.2347 0.5 2.5 1.0


### PR DESCRIPTION
- Add launch_psim script to launch the Planning Simulator
- Add set_obstacles script to place dummy objects in the S-curve area
  - Imitate the four walls of the S-curve task, each wall with different widths. 

![image](https://github.com/AutomotiveAIChallenge/aichallenge2023-integration-final/assets/5180742/928e01ce-0b39-4a7e-a1d1-af6bdb9698ff)
