### PR TITLE
fix: update scoring params to newest map

### DIFF
--- a/src/aichallenge_scoring/aichallenge_scoring/config/aichallenge_scoring.param.yaml
+++ b/src/aichallenge_scoring/aichallenge_scoring/config/aichallenge_scoring.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    task1_start_distance: 8.0  # Distance of the start line for Task 1
-    task1_end_distance: 11.0    # Distance of the end line for Task 1+3m
-    task3_start_distance: 28.8  # Distance of the start line for Task 3
-    task3_end_distance: 170.0    # Distance of the end line for Task 3
+    task1_start_distance: 4.8  # Distance of the start line for Task 1
+    task1_end_distance: 7.8    # Distance of the end line for Task 1+3m
+    task3_start_distance: 22.2  # Distance of the start line for Task 3
+    task3_end_distance: 177.8    # Distance of the end line for Task 3


### PR DESCRIPTION
- 課題1の停止位置を指定するパラメータを修正
  - 課題1の段ボールまでの距離は13.4m
  - 段ボールの手前6m~3mの範囲で車両先頭が来るように停止する
  - `task1_start_distance`: 13.4 - 6 - 2.6(base_linkから車両先頭までの距離) = 4.8m
  - `task1_end_distance`:  4.8 + 3 = 7.8m
- 課題3の開始地点と終了地点を指定するパラメータを修正
  - `task3_start_distance`: 煙マシンを通過してレーンが開け始めた辺り
  - `task3_end_distance`: ゴール箇所は元の170mより奥にあった．ゴールした時の距離点が177.8m